### PR TITLE
infra: add PYTHONPATH default to container

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -28,6 +28,7 @@ resource "docker_container" "airflow" {
   # - Disable example DAGs.
   # - Setup SimpleAuthManager so that all users are admins (only for local development to remove User authentication).
   env = [
+    "PYTHONPATH=/opt/airflow",
     "AIRFLOW__CORE__DAGS_FOLDER=/opt/airflow/dags",
     "AIRFLOW__CORE__LOAD_EXAMPLES=False",
     "AIRFLOW__CORE__AUTH_MANAGER=airflow.api_fastapi.auth.managers.simple.simple_auth_manager.SimpleAuthManager",


### PR DESCRIPTION
Airflow needs a default path to see Python scripts inside /opt/airflow/elt.